### PR TITLE
Update resnet.py

### DIFF
--- a/keras/applications/resnet.py
+++ b/keras/applications/resnet.py
@@ -178,7 +178,7 @@ def ResNet(
     x = layers.ZeroPadding2D(padding=((3, 3), (3, 3)), name="conv1_pad")(
         img_input
     )
-    x = layers.Conv2D(64, 7, strides=2, use_bias=use_bias, name="conv1_conv")(x)
+    x = layers.Conv2D(64, 7, strides=2, use_bias=use_bias, padding='same', name="conv1_conv")(x)
 
     if not preact:
         x = layers.BatchNormalization(
@@ -186,8 +186,8 @@ def ResNet(
         )(x)
         x = layers.Activation("relu", name="conv1_relu")(x)
 
-    x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name="pool1_pad")(x)
-    x = layers.MaxPooling2D(3, strides=2, name="pool1_pool")(x)
+    x = layers.ZeroPadding2D(padding=((1, 0), (1, 0)), name="pool1_pad")(x)
+    x = layers.MaxPooling2D(3, strides=2,padding='valid', name="pool1_pool")(x)
 
     x = stack_fn(x)
 


### PR DESCRIPTION
I've changed the pool1_pad layer's padding to (1, 0) for the right and bottom edges. This will ensure that the padding is added only on the top and left sides, which compensates for the even-sized input.
I've changed the MaxPooling2D layer's padding to 'valid', which is equivalent to "SAME" padding in this context because of the additional padding added by pool1_pad.